### PR TITLE
default -> defaults, should fix #138

### DIFF
--- a/www/js/lib/utils.js
+++ b/www/js/lib/utils.js
@@ -66,7 +66,7 @@ define(['jquery', 'underscore', 'backbone', 'app'], function($, _, Backbone, app
 	 */
 	 var Error = Backbone.Model.extend({
 	 	// default values for an error
-	 	default:{
+	 	defaults: {
 	 		msg: 'Es ist ein Fehler aufgetreten.',
 	 		module: 'Modul nicht bekannt'
 	 	},


### PR DESCRIPTION
- `default` ist ein altes JS Reserved Keyword
- `defaults` ist das richtige Backbone-Keyword
