### PR TITLE
Feature/grade dual degree fix

### DIFF
--- a/src/app/pages/grades/grades.page.html
+++ b/src/app/pages/grades/grades.page.html
@@ -32,7 +32,7 @@
               {{ studentDetails.Abschl }} ({{ studentDetails.Studiengaenge.dtxt }})
             </div>
           </div>
-          <div *ngIf="isDualDegree[0]">
+          <div *ngIf="isDualDegree[0] && studentDetails.AbLtxt">
             {{ studentDetails.AbLtxt }}
           </div>
         </ion-label>
@@ -52,10 +52,9 @@
               {{ degree.Abschl }} ({{ degree.Studiengaenge.dtxt }})
             </div>
           </div>
-          <div *ngIf="isDualDegree[i]">
+          <div *ngIf="isDualDegree[i] && degree.AbLtxt">
             {{ degree.AbLtxt }}
           </div>
-
         </ion-label>
       </ion-item>
     </ion-list>

--- a/src/app/pages/grades/grades.page.html
+++ b/src/app/pages/grades/grades.page.html
@@ -27,8 +27,13 @@
     <ion-list>
       <ion-item color="primary" class="studiengang" lines="none" (click)="showGrades(0)">
         <ion-label text-wrap>
-          <div *ngIf="studentDetails.Studiengaenge && studentDetails.Studiengaenge.dtxt && studentDetails.Abschl">
-            {{ studentDetails.Abschl }} ({{ studentDetails.Studiengaenge.dtxt }})
+          <div *ngIf="!isDualDegree[0]">
+            <div *ngIf="studentDetails.Studiengaenge && studentDetails.Studiengaenge.dtxt && studentDetails.Abschl">
+              {{ studentDetails.Abschl }} ({{ studentDetails.Studiengaenge.dtxt }})
+            </div>
+          </div>
+          <div *ngIf="isDualDegree[0]">
+            {{ studentDetails.AbLtxt }}
           </div>
         </ion-label>
       </ion-item>
@@ -42,9 +47,15 @@
     <ion-list>
       <ion-item color="primary" *ngFor="let degree of studentDetails; let i = index" class="studiengang" lines="none" (click)="showGrades(i)">
         <ion-label text-wrap>
-          <div *ngIf="degree.Studiengaenge && degree.Studiengaenge.dtxt && degree.Abschl">
-            {{ degree.Abschl }} ({{ degree.Studiengaenge.dtxt }})
+          <div *ngIf="!isDualDegree[i]">
+            <div *ngIf="degree.Studiengaenge && degree.Studiengaenge.dtxt && degree.abschl">
+              {{ degree.Abschl }} ({{ degree.Studiengaenge.dtxt }})
+            </div>
           </div>
+          <div *ngIf="isDualDegree[i]">
+            {{ degree.AbLtxt }}
+          </div>
+
         </ion-label>
       </ion-item>
     </ion-list>


### PR DESCRIPTION
Bei Lehramtsstudenten (und bestimmt auch einigen anderen) die unter dem dach eines abschlusses mehrere Studiengänge haben wurde kein Text in der Leistungsübersicht angezeigt. Es war zwar schon im script support dafür festzustellen ob mehrere Studiengänge von der API zurück gegeben werden, aber das wurde nirgens benutzt. 

Ich habe das jetzt mal eingebaut das es funktioniert, leider habe ich jedoch nur einen account zum testen das ich konnte nicht alles testen weil ich nicht weiß wie die API results für beispielsweise master lehramt aussehen, wenn ihr da test nutzer habt könntet ihr das ggf mal testen.

vorher:
<img width="364" alt="2019-04-08_11-32_Ionic_App_-_Google_Chrome" src="https://user-images.githubusercontent.com/6819595/55716272-dad91f00-59f6-11e9-9d04-2f57b153f632.png">

nachher:
<img width="1270" alt="2019-04-08_09-47_Ionic_App_-_Google_Chrome" src="https://user-images.githubusercontent.com/6819595/55716271-dad91f00-59f6-11e9-9769-550304aecdd5.png">
