### PR TITLE
refactored swiping in remaining pages by using the CampusTabComponent directly

### DIFF
--- a/src/app/components/campus-tab/campus-tab.component.ts
+++ b/src/app/components/campus-tab/campus-tab.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { Events } from '@ionic/angular';
 import { SettingsService } from 'src/app/services/settings/settings.service';
 import { ICampus } from '../../lib/interfaces';
 import { ConfigService } from '../../services/config/config.service';
@@ -50,8 +49,7 @@ export class CampusTabComponent implements OnInit {
   _selectedCampus: ICampus;
 
   constructor(
-    private settings: SettingsService,
-    private swipeEvent: Events
+    private settings: SettingsService
   ) {  }
 
   /**
@@ -96,21 +94,7 @@ export class CampusTabComponent implements OnInit {
    * initializes this component
    */
   ngOnInit() {
-    this.initSwipeEvents();
     this.initCampusTab();
-  }
-
-  /**
-   * initializes the swipe events for this component
-   */
-  initSwipeEvents() {
-    this.swipeEvent.subscribe('campus-swipe-to-right',
-      () => { this.selectNextCampus(); }
-    );
-
-    this.swipeEvent.subscribe('campus-swipe-to-left',
-      () => { this.selectPreviousCampus(); }
-    );
   }
 
   /**

--- a/src/app/pages/free-rooms/free-rooms.page.ts
+++ b/src/app/pages/free-rooms/free-rooms.page.ts
@@ -2,7 +2,6 @@ import {Component, OnInit, ViewChild} from '@angular/core';
 import { HttpErrorResponse, HttpHeaders, HttpParams, HttpClient } from '@angular/common/http';
 import { CacheService } from 'ionic-cache';
 import { RoomplanPage } from '../roomplan/roomplan.page';
-import { Events } from '@ionic/angular';
 import {IHouse, IRoomApiRequest, IRoomRequestResponse, IRoom, ICampus} from 'src/app/lib/interfaces';
 import { AlertService } from 'src/app/services/alert/alert.service';
 import { WebHttpUrlEncodingCodec } from 'src/app/services/login-provider/lib';
@@ -33,8 +32,7 @@ export class FreeRoomsPage extends AbstractPage implements OnInit {
   constructor(
     private cache: CacheService,
     private http: HttpClient,
-    private alertProvider: AlertService,
-    private swipeEvent: Events
+    private alertProvider: AlertService
   ) {
     super({ requireNetwork: true });
   }

--- a/src/app/pages/mensa/mensa.page.ts
+++ b/src/app/pages/mensa/mensa.page.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import { CalendarComponentOptions } from 'ion2-calendar';
 import * as moment from 'moment';
 import { TranslateService } from '@ngx-translate/core';
@@ -7,6 +7,7 @@ import { HttpHeaders, HttpParams, HttpClient } from '@angular/common/http';
 import { Events } from '@ionic/angular';
 import {ICampus, IMeals, IMensaResponse} from 'src/app/lib/interfaces';
 import { AbstractPage } from 'src/app/lib/abstract-page';
+import {CampusTabComponent} from '../../components/campus-tab/campus-tab.component';
 
 @Component({
   selector: 'app-mensa',
@@ -55,11 +56,12 @@ export class MensaPage extends AbstractPage {
   noUlfMealsForDate;
   campus;
 
+  @ViewChild(CampusTabComponent) campusTabComponent: CampusTabComponent;
+
   constructor(
     private translate: TranslateService,
     private cache: CacheService,
-    private http: HttpClient,
-    private swipeEvent: Events
+    private http: HttpClient
   ) {
     super({ requireNetwork: true });
   }
@@ -337,10 +339,10 @@ export class MensaPage extends AbstractPage {
     if (Math.abs(event.deltaY) < 50) {
       if (event.deltaX > 0) {
         // user swiped from left to right
-        this.swipeEvent.publish('campus-swipe-to-right', this.campus);
+        this.campusTabComponent.selectPreviousCampus();
       } else if (event.deltaX < 0) {
         // user swiped from right to left
-        this.swipeEvent.publish('campus-swipe-to-left', this.campus);
+        this.campusTabComponent.selectNextCampus();
       }
     }
   }

--- a/src/app/pages/roomplan/roomplan.page.ts
+++ b/src/app/pages/roomplan/roomplan.page.ts
@@ -1,7 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import { HttpErrorResponse, HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { CacheService } from 'ionic-cache';
-import { Events } from '@ionic/angular';
 import { AlertService } from 'src/app/services/alert/alert.service';
 import {
   IHouse,
@@ -15,6 +14,7 @@ import {
 } from 'src/app/lib/interfaces';
 import { WebHttpUrlEncodingCodec } from 'src/app/services/login-provider/lib';
 import { AbstractPage } from 'src/app/lib/abstract-page';
+import {CampusTabComponent} from '../../components/campus-tab/campus-tab.component';
 
 @Component({
   selector: 'app-roomplan',
@@ -27,8 +27,7 @@ export class RoomplanPage extends AbstractPage implements OnInit {
     private http: HttpClient,
     private cache: CacheService,
     private alert: AlertService,
-    private alertProvider: AlertService,
-    private swipeEvent: Events
+    private alertProvider: AlertService
   ) {
     super({ requireNetwork: true });
   }
@@ -50,6 +49,8 @@ export class RoomplanPage extends AbstractPage implements OnInit {
   current_location: string;
   error: HttpErrorResponse;
   requestProcessed = false;
+
+  @ViewChild(CampusTabComponent) campusTabComponent: CampusTabComponent;
 
   /**
    * Comparator for event sorting
@@ -109,28 +110,6 @@ export class RoomplanPage extends AbstractPage implements OnInit {
       this.days.push({'lbl': day, 'value': i.toString()});
     }
     this.select_day = this.day_offset;
-  }
-
-  /**
-   * Convert campus number to short string (for localization)
-   * @param num - Campus number (1-3)
-   * @returns {string} - campus short string (gs,np,go), defaults to gs
-   */
-  getLocationByNum(num) { // one could use numbers everywhere, but this is better for readability
-    switch (num) {
-      case '1': {
-        return 'NeuesPalais';
-      }
-      case '2': {
-        return 'Golm';
-      }
-      case '3': {
-        return 'Griebnitzsee';
-      }
-      default: {
-        return 'Griebnitzsee';
-      }
-    }
   }
 
   /**
@@ -397,10 +376,10 @@ export class RoomplanPage extends AbstractPage implements OnInit {
     if (Math.abs(event.deltaY) < 50) {
       if (event.deltaX > 0) {
         // user swiped from left to right
-        this.swipeEvent.publish('campus-swipe-to-right', this.getLocationByNum(this.current_location));
+        this.campusTabComponent.selectPreviousCampus();
       } else if (event.deltaX < 0) {
         // user swiped from right to left
-        this.swipeEvent.publish('campus-swipe-to-left', this.getLocationByNum(this.current_location));
+        this.campusTabComponent.selectNextCampus();
       }
     }
   }

--- a/src/app/pages/transport/transport.page.ts
+++ b/src/app/pages/transport/transport.page.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import { HttpParams, HttpHeaders, HttpClient } from '@angular/common/http';
 import * as moment from 'moment';
 import { Events } from '@ionic/angular';
 import {ICampus, IJourneyResponse} from 'src/app/lib/interfaces';
 import { AbstractPage } from 'src/app/lib/abstract-page';
+import {CampusTabComponent} from '../../components/campus-tab/campus-tab.component';
 
 @Component({
   selector: 'app-transport',
@@ -23,9 +24,10 @@ export class TransportPage extends AbstractPage {
 
   error = null;
 
+  @ViewChild(CampusTabComponent) campusTabComponent: CampusTabComponent;
+
   constructor(
-    private http: HttpClient,
-    private swipeEvent: Events
+    private http: HttpClient
   ) {
     super({ requireNetwork: true });
   }
@@ -114,10 +116,10 @@ export class TransportPage extends AbstractPage {
     if (Math.abs(event.deltaY) < 50) {
       if (event.deltaX > 0) {
         // user swiped from left to right
-        this.swipeEvent.publish('campus-swipe-to-right', this.campus);
+        this.campusTabComponent.selectPreviousCampus();
       } else if (event.deltaX < 0) {
         // user swiped from right to left
-        this.swipeEvent.publish('campus-swipe-to-left', this.campus);
+        this.campusTabComponent.selectNextCampus();
       }
     }
   }


### PR DESCRIPTION
Swipe-Event wird nicht mehr benötig, da die CampusTabComponent auch direkt aufgerufen werden kann, um zum nächsten/vorherigen Tab zu springen.