### PR TITLE
fixed day of week not been shown in date picker

### DIFF
--- a/src/app/components/date-picker/date-picker.component.html
+++ b/src/app/components/date-picker/date-picker.component.html
@@ -3,7 +3,7 @@
   <ion-label *ngIf="compactMode">{{ currentDay }}</ion-label>
   <ion-select [(ngModel)]="dayOffset" (ionChange)="emitDayChange()" [selectedText]="selectedText" okText="{{ 'button.ok' | translate }}" cancelText="{{ 'button.cancel'  | translate }}">
     <ion-select-option *ngFor="let day of days" [value]="day.value">
-      {{ day.lbl.toLocaleDateString(translate.currentLang) }}
+      {{ day.lbl }}
     </ion-select-option>
   </ion-select>
 </ion-item>

--- a/src/app/components/date-picker/date-picker.component.ts
+++ b/src/app/components/date-picker/date-picker.component.ts
@@ -47,7 +47,7 @@ export class DatePickerComponent implements OnInit {
     for (let i = 0; i < 7; i++) {
       const day: Date = new Date();
       day.setDate(day.getDate() + i);
-      this.days.push({'lbl': day, 'value': i.toString()});
+      this.days.push({'lbl': moment(day).format('ddd D. MMMM'), 'value': i.toString()});
     }
     this.dayOffset = day_offset;
     this.emitDayChange();
@@ -58,7 +58,7 @@ export class DatePickerComponent implements OnInit {
 
     for (let i = 0; i < this.days.length; i++) {
       if (this.days[i].value === this.dayOffset) {
-        this.currentDay = this.days[i].lbl.toLocaleDateString(this.translate.currentLang);
+        this.currentDay = this.days[i].lbl;
       }
     }
 

--- a/src/app/components/date-picker/date-picker.component.ts
+++ b/src/app/components/date-picker/date-picker.component.ts
@@ -47,7 +47,7 @@ export class DatePickerComponent implements OnInit {
     for (let i = 0; i < 7; i++) {
       const day: Date = new Date();
       day.setDate(day.getDate() + i);
-      this.days.push({'lbl': moment(day).format('ddd D. MMMM'), 'value': i.toString()});
+      this.days.push({'lbl': moment(day).format('ddd D. MMM'), 'value': i.toString()});
     }
     this.dayOffset = day_offset;
     this.emitDayChange();


### PR DESCRIPTION
Die Date picker (z.B. auf der Mensa Seite) haben nur das Datum angezeigt und nicht den Tag der Woche. Das war extrem unpraktisch da man immer das Datum abzählen musste. Ich habe das angepasst, das spart auch gleich die Verwirrung dadurch das das attribut `lbl` nicht wie der name suggestieren würde ein string der als label benutzt wird sondern ein objekt ist was an 3 stellen formatiert werden muss.

Ich habe diverse Seiten getestet und geschaut ob alles funktioniert und konnte keine Probleme feststellen, auch die lokalisierung funktioniert.

Es wäre schön wenn dieses Feature (oder wegen mir auch ein anderer fix fürs gleiche Problem) bald umgesetzt werden könnte da so der Mensa Plan quasi unbenutzbar ist.