### PR TITLE
changed vbb station to show regional trains for golm in transport

### DIFF
--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -328,7 +328,7 @@
       "pretty_name": "Golm",
       "canteen_name": "Golm",
       "shortcode": "go",
-      "transport_station_id": "900220365",
+      "transport_station_id": "900220010",
       "coordinates": [52.41527, 12.96941],
       "lat_long_bounds": [
         [


### PR DESCRIPTION
switchting to this vbb station shows regional trains which is very usefull when traveling between golm and griebnitzsee, it doesn't get you less bus options

vabene told me you appreciate pull requests for stuff like this that you only realize in a special use case