### PR TITLE
fixed date in timetable detail view

### DIFF
--- a/src/app/pages/timetable/event.modal.ts
+++ b/src/app/pages/timetable/event.modal.ts
@@ -43,7 +43,7 @@ export class EventModalPage implements OnInit {
                     if (startArray.length > 2) {
                         this.events[i].eventDetails.startDate = new Date(
                             startArray[2],
-                            startArray[1],
+                            startArray[1] - 1, // Javascript dates range from 0-11
                             startArray[0]
                         );
                     }
@@ -51,7 +51,7 @@ export class EventModalPage implements OnInit {
                     if (endArray.length > 2) {
                         this.events[i].eventDetails.endDate = new Date(
                             endArray[2],
-                            endArray[1],
+                            endArray[1] - 1, // Javascript dates range from 0-11
                             endArray[0]
                         );
                     }


### PR DESCRIPTION
javascript dates range from 0-11

fixes months displayed wrong in timetable details

![image](https://user-images.githubusercontent.com/9949045/66745140-866b9c00-ee7e-11e9-8dbc-a20255603a15.png)
